### PR TITLE
Use ansible from EPEL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,8 @@ LABEL "com.github.actions.color"="green"
 
 RUN yum update --assumeyes && yum install --assumeyes epel-release
 
-RUN yum install --assumeyes python \
-    python-pip \
+RUN yum install --assumeyes ansible \
     git
-
-RUN pip install setuptools && pip install ansible
 
 RUN ansible --version
 


### PR DESCRIPTION
Currently, installation of cryptography module fails. I do not see centos7 updating the pip so we need to update pip on our own.

The error was:
```
  Collecting cryptography (from ansible-base<2.11,>=2.10.5->ansible)
    Downloading https://files.pythonhosted.org/packages/60/6d/b32368327f600a12e59fb51a904fc6200dd7e65e953fd6fc6ae6468e3423/cryptography-3.4.5.tar.gz (546kB)
      Complete output from command python setup.py egg_info:
      
              =============================DEBUG ASSISTANCE==========================
              If you are seeing an error here please try the following to
              successfully install cryptography:
      
              Upgrade to the latest pip and try again. This will fix errors for most
              users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
              =============================DEBUG ASSISTANCE==========================
      
      Traceback (most recent call last):
        File "<string>", line 1, in <module>
        File "/tmp/pip-build-Rdwj3N/cryptography/setup.py", line 14, in <module>
          from setuptools_rust import RustExtension
      ImportError: No module named setuptools_rust
      
      ----------------------------------------
  Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-Rdwj3N/cryptography/
  You are using pip version 8.1.2, however version 21.0.1 is available.
  You should consider upgrading via the 'pip install --upgrade pip' command.
```
Example log (will probably expire soon): 

https://github.com/willshersystems/ansible-sshd/pull/150/checks?check_run_id=1912844571